### PR TITLE
Feature/use isp missing helper report

### DIFF
--- a/Dockerfiles/AutoDeductDockerfile
+++ b/Dockerfiles/AutoDeductDockerfile
@@ -134,6 +134,8 @@ EOF
 #
 FROM auto-deduct-base AS auto-deduct-frama-c
 
+ARG FRAMA_C_VER="31.0"
+
 USER dev
 WORKDIR /home/dev
 
@@ -155,6 +157,9 @@ RUN . /home/dev/.profile && \
 # Stage 3 - Add Scala related stuff
 #
 FROM auto-deduct-frama-c AS auto-deduct-scala
+
+ARG PROXY_HOST=""
+ARG PROXY_PORT=""
 
 USER dev
 WORKDIR /home/dev
@@ -180,6 +185,8 @@ RUN curl -fLo coursierLauncher https://github.com/coursier/launchers/raw/master/
 #
 FROM auto-deduct-scala AS auto-deduct-tricera
 
+ARG TRICERA_VER="5324b60f43e3e90314a151d056e5559a0ec3d63e"
+
 USER dev
 WORKDIR /home/dev/repos
 
@@ -203,6 +210,9 @@ RUN ln -s /home/dev/repos/tricera/tri && \
 #   it after the container image has been built.
 #
 FROM auto-deduct-tricera AS auto-deduct-toolchain
+
+ARG SAIDA_VER="v0.5.0"
+ARG ISP_VER="v0.3.1"
 
 USER dev
 WORKDIR /home/dev/repos

--- a/Dockerfiles/AutoDeductDockerfile
+++ b/Dockerfiles/AutoDeductDockerfile
@@ -106,7 +106,9 @@ RUN update-ca-certificates && \
 # Set up a new user in the container
 RUN  adduser --disabled-password --shell /usr/bin/bash --uid ${UID} --gecos "Development user" dev && \
   echo "dev:dev" | chpasswd && \
-  usermod -aG sudo dev
+  usermod -aG sudo dev && \
+  mkdir -p /home/dev/repos /home/dev/.local/bin && \
+  chown -R dev:dev /home/dev
 
 USER dev
 WORKDIR /home/dev

--- a/Dockerfiles/bin/autodeduct-contract-assistant
+++ b/Dockerfiles/bin/autodeduct-contract-assistant
@@ -25,8 +25,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import shlex
+import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -89,10 +93,13 @@ class FileReport:
     missing_contracts: list[FunctionInfo]
     missing_helper_contracts: list[FunctionInfo]
     called_by: dict[str, list[str]]
+    analysis_backend: str = "source-scan"
+    analysis_warning: str | None = None
 
     def to_json(self) -> dict[str, object]:
-        return {
+        report = {
             "file": str(self.path),
+            "analysis_backend": self.analysis_backend,
             "functions": [function.to_json() for function in self.functions],
             "missing_contracts": [
                 function.to_json() for function in self.missing_contracts
@@ -102,6 +109,9 @@ class FileReport:
             ],
             "called_by": self.called_by,
         }
+        if self.analysis_warning:
+            report["analysis_warning"] = self.analysis_warning
+        return report
 
 
 def line_of(text: str, index: int) -> int:
@@ -335,6 +345,186 @@ def reachable_from_contracted(functions: list[FunctionInfo]) -> set[tuple[Path, 
     return reachable
 
 
+def split_extra_args(extra_args: str | list[str] | None) -> list[str]:
+    if extra_args is None:
+        return []
+    if isinstance(extra_args, list):
+        return [str(arg) for arg in extra_args if str(arg)]
+    if not extra_args.strip():
+        return []
+    return shlex.split(extra_args)
+
+
+def common_source_root(source_paths: list[Path]) -> Path:
+    if not source_paths:
+        return Path.cwd()
+    parents = [str(path.resolve().parent) for path in source_paths]
+    return Path(os.path.commonpath(parents))
+
+
+def compact_command_output(output: str, limit: int = 900) -> str:
+    cleaned = output.strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 80].rstrip() + "\n... output truncated ..."
+
+
+def run_isp_missing_helper_report(
+    source_paths: list[Path],
+    root: Path,
+    extra_args: str | list[str] | None = None,
+) -> dict[str, object]:
+    c_paths = [path for path in source_paths if path.suffix.lower() == ".c"]
+    if not c_paths:
+        raise RuntimeError("ISP backend needs at least one .c file")
+
+    with tempfile.TemporaryDirectory(prefix="autodeduct-isp-report-") as tmpdir:
+        report_path = Path(tmpdir) / "missing-helper-contracts.json"
+        command = [
+            "frama-c",
+            "-autoload-plugins",
+            "-isp-missing-helper-contracts-json",
+            str(report_path),
+            *split_extra_args(extra_args),
+            *[str(path.resolve()) for path in c_paths],
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                cwd=root,
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=120,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError("frama-c was not found") from exc
+        except subprocess.TimeoutExpired as exc:
+            output = exc.stdout or ""
+            raise RuntimeError(
+                "frama-c timed out while generating the ISP missing-helper report"
+                + (f": {compact_command_output(output)}" if output else "")
+            ) from exc
+
+        if result.returncode != 0:
+            output = compact_command_output(result.stdout)
+            raise RuntimeError(
+                "frama-c could not generate the ISP missing-helper report"
+                + (f": {output}" if output else "")
+            )
+        if not report_path.exists():
+            raise RuntimeError("ISP did not write the missing-helper JSON report")
+
+        return json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def path_matches_isp_file(path: Path, isp_file: object, root: Path) -> bool:
+    if not isinstance(isp_file, str) or not isp_file:
+        return False
+
+    normalized = isp_file.replace("\\", "/")
+    candidates = {
+        str(path).replace("\\", "/"),
+        str(path.resolve()).replace("\\", "/"),
+        path.name,
+    }
+    try:
+        candidates.add(str(path.resolve().relative_to(root.resolve())).replace("\\", "/"))
+    except ValueError:
+        pass
+
+    return any(candidate == normalized or candidate.endswith("/" + normalized) for candidate in candidates)
+
+
+def caller_names_from_isp_item(item: dict[str, object]) -> list[str]:
+    names: list[str] = []
+    callers = item.get("called_by", [])
+    if not isinstance(callers, list):
+        return names
+    for caller in callers:
+        if isinstance(caller, dict):
+            name = caller.get("function")
+            if isinstance(name, str):
+                append_unique(names, name)
+    return names
+
+
+def find_isp_report_function(
+    reports: list[FileReport], item: dict[str, object], root: Path
+) -> tuple[FileReport, FunctionInfo] | None:
+    name = item.get("function")
+    if not isinstance(name, str):
+        return None
+
+    line: int | None = None
+    raw_line = item.get("line")
+    if isinstance(raw_line, int):
+        line = raw_line
+
+    candidates: list[tuple[FileReport, FunctionInfo]] = []
+    for report in reports:
+        if not path_matches_isp_file(report.path, item.get("file"), root):
+            continue
+        candidates.extend(
+            (report, function)
+            for function in report.functions
+            if function.name == name
+        )
+
+    if line is not None:
+        line_matches = [
+            (report, function)
+            for report, function in candidates
+            if function.line == line
+        ]
+        if len(line_matches) == 1:
+            return line_matches[0]
+
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def apply_isp_missing_helper_report(
+    reports: list[FileReport], isp_report: dict[str, object], root: Path
+) -> list[FileReport]:
+    raw_missing = isp_report.get("missing_helper_contracts", [])
+    if not isinstance(raw_missing, list):
+        raise RuntimeError("ISP report has no missing_helper_contracts list")
+
+    matches: list[tuple[FileReport, FunctionInfo, list[str]]] = []
+    unmatched: list[str] = []
+    for item in raw_missing:
+        if not isinstance(item, dict):
+            unmatched.append(str(item))
+            continue
+        match = find_isp_report_function(reports, item, root)
+        if match is None:
+            unmatched.append(json.dumps(item, sort_keys=True))
+            continue
+        report, function = match
+        matches.append((report, function, caller_names_from_isp_item(item)))
+
+    if unmatched:
+        raise RuntimeError(
+            "could not map ISP missing-helper report item(s) back to source scan: "
+            + "; ".join(unmatched)
+        )
+
+    for report in reports:
+        report.missing_helper_contracts = []
+        report.analysis_backend = "isp-frama-c"
+        report.analysis_warning = None
+
+    for report, function, callers in matches:
+        if function not in report.missing_helper_contracts:
+            report.missing_helper_contracts.append(function)
+        report.called_by[function.name] = callers
+
+    return reports
+
+
 def analyze_file(path: Path, include_main: bool) -> FileReport:
     text = path.read_text(encoding="utf-8")
     functions = discover_functions(path, text)
@@ -376,7 +566,7 @@ def collect_source_paths(paths: list[Path]) -> list[Path]:
     return source_paths
 
 
-def analyze_files(paths: list[Path], include_main: bool) -> list[FileReport]:
+def analyze_files_source_scan(paths: list[Path], include_main: bool) -> list[FileReport]:
     source_paths = collect_source_paths(paths)
     texts = {path: path.read_text(encoding="utf-8") for path in source_paths}
     functions_by_path = {
@@ -415,10 +605,41 @@ def analyze_files(paths: list[Path], include_main: bool) -> list[FileReport]:
     return reports
 
 
+def analyze_files(
+    paths: list[Path],
+    include_main: bool,
+    backend: str = "auto",
+    extra_args: str | list[str] | None = None,
+    root: Path | None = None,
+) -> list[FileReport]:
+    source_paths = collect_source_paths(paths)
+    reports = analyze_files_source_scan(source_paths, include_main)
+    if backend == "source":
+        return reports
+
+    analysis_root = root or common_source_root(source_paths)
+    try:
+        isp_report = run_isp_missing_helper_report(
+            source_paths, analysis_root, extra_args
+        )
+        return apply_isp_missing_helper_report(reports, isp_report, analysis_root)
+    except RuntimeError as exc:
+        if backend == "isp":
+            raise
+        warning = f"ISP/Frama-C backend unavailable; using source scan: {exc}"
+        for report in reports:
+            report.analysis_backend = "source-scan"
+            report.analysis_warning = warning
+        return reports
+
+
 def format_text_report(reports: list[FileReport]) -> str:
     lines: list[str] = ["AutoDeduct contract assistant report", ""]
     for report in reports:
         lines.append(f"File: {report.path}")
+        lines.append(f"  Analysis backend: {report.analysis_backend}")
+        if report.analysis_warning:
+            lines.append(f"  Analysis warning: {report.analysis_warning}")
         lines.append(f"  Functions found: {len(report.functions)}")
         contracted = [function.name for function in report.functions if function.has_contract]
         lines.append(
@@ -489,6 +710,25 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="include main when reporting functions missing contracts",
     )
     parser.add_argument(
+        "--backend",
+        choices=("auto", "source", "isp"),
+        default="auto",
+        help=(
+            "missing-helper backend: auto prefers ISP/Frama-C and falls back to "
+            "the source scan, source uses only the built-in scanner, isp requires "
+            "the ISP JSON report"
+        ),
+    )
+    parser.add_argument(
+        "--frama-c-extra-args",
+        default=None,
+        metavar="ARGS",
+        help=(
+            "extra Frama-C options for the ISP backend, for example "
+            "'-cpp-extra-args=\"-D__GNUC__=12 -Ioriginal\"'"
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="print a machine-readable JSON report",
@@ -509,7 +749,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    reports = analyze_files(args.files, args.include_main)
+    reports = analyze_files(
+        args.files,
+        args.include_main,
+        backend=args.backend,
+        extra_args=args.frama_c_extra_args,
+    )
 
     if args.llm_prompt is not None:
         args.llm_prompt.write_text(format_llm_prompt(reports), encoding="utf-8")

--- a/Dockerfiles/bin/autodeduct-contract-assistant-gui
+++ b/Dockerfiles/bin/autodeduct-contract-assistant-gui
@@ -131,7 +131,7 @@ HTML_PAGE = r"""<!doctype html>
       font-size: 13px;
       color: var(--muted);
     }
-    input[type="text"], textarea {
+    input[type="text"], select, textarea {
       width: 100%;
       border: 1px solid var(--border);
       border-radius: 6px;
@@ -144,6 +144,9 @@ HTML_PAGE = r"""<!doctype html>
       min-height: 480px;
       resize: vertical;
       line-height: 1.4;
+    }
+    select {
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
     .row {
       display: flex;
@@ -328,6 +331,12 @@ HTML_PAGE = r"""<!doctype html>
       <div id="pathBrowser" class="path-browser hidden"></div>
       <label for="framacArgs">Extra Frama-C options</label>
       <input id="framacArgs" type="text" placeholder='-cpp-extra-args="-D__GNUC__=12 -Ioriginal"'>
+      <label for="analysisBackend">Missing-helper backend</label>
+      <select id="analysisBackend">
+        <option value="auto">Auto: ISP/Frama-C with source-scan fallback</option>
+        <option value="isp">ISP/Frama-C only</option>
+        <option value="source">Source scan only</option>
+      </select>
       <div class="row">
         <button id="run">Run Assistant</button>
         <button class="secondary" id="generateDraft">Generate Contract Draft</button>
@@ -359,6 +368,7 @@ HTML_PAGE = r"""<!doctype html>
   <script>
     const projectPathInput = document.getElementById("projectPath");
     const framacArgsInput = document.getElementById("framacArgs");
+    const analysisBackendInput = document.getElementById("analysisBackend");
     const includeMain = document.getElementById("includeMain");
     const runButton = document.getElementById("run");
     const generateDraftButton = document.getElementById("generateDraft");
@@ -486,7 +496,8 @@ HTML_PAGE = r"""<!doctype html>
           body: JSON.stringify({
             project_path: requestProjectPath(),
             include_main: includeMain.checked,
-            extra_args: framacArgsInput.value
+            extra_args: framacArgsInput.value,
+            backend: analysisBackendInput.value
           })
         });
         const data = await response.json();
@@ -517,7 +528,8 @@ HTML_PAGE = r"""<!doctype html>
           body: JSON.stringify({
             project_path: requestProjectPath(),
             include_main: includeMain.checked,
-            extra_args: framacArgsInput.value
+            extra_args: framacArgsInput.value,
+            backend: analysisBackendInput.value
           })
         });
         const data = await response.json();
@@ -689,6 +701,15 @@ def has_project_path(payload: dict[str, object]) -> bool:
     return isinstance(project_path, str) and bool(project_path.strip())
 
 
+def analysis_backend_from_payload(payload: dict[str, object]) -> str:
+    backend = payload.get("backend", "auto")
+    if not isinstance(backend, str):
+        raise ValueError("Analysis backend must be a string")
+    if backend not in ("auto", "isp", "source"):
+        raise ValueError("Analysis backend must be one of: auto, isp, source")
+    return backend
+
+
 def list_project_path(project_path: str | None) -> dict[str, object]:
     return list_container_path(project_path, ASSISTANT.SOURCE_SUFFIXES)
 
@@ -697,10 +718,11 @@ def suggest_contracts(
     project_path: str,
     include_main: bool = False,
     extra_args: str | list[str] | None = None,
+    backend: str = "auto",
 ) -> dict[str, object]:
     root, source_paths = source_paths_from_project_path(project_path, ASSISTANT)
     reports = ASSISTANT.analyze_files(
-        source_paths, include_main, extra_args=extra_args, root=root
+        source_paths, include_main, backend=backend, extra_args=extra_args, root=root
     )
     return suggest_contracts_from_reports(reports, root, pipeline_for_reports)
 
@@ -709,6 +731,7 @@ def analyze_project(
     files: list[dict[str, str]],
     include_main: bool = False,
     extra_args: str | list[str] | None = None,
+    backend: str = "auto",
 ) -> dict[str, object]:
     with tempfile.TemporaryDirectory(prefix="autodeduct-contract-assistant-") as tmpdir:
         root = Path(tmpdir)
@@ -719,7 +742,7 @@ def analyze_project(
         if not source_paths:
             raise ValueError("No .c or .h source files were provided")
         reports = ASSISTANT.analyze_files(
-            source_paths, include_main, extra_args=extra_args, root=root
+            source_paths, include_main, backend=backend, extra_args=extra_args, root=root
         )
         text_report = ASSISTANT.format_text_report(reports)
         llm_prompt = ASSISTANT.format_llm_prompt(reports)
@@ -736,10 +759,11 @@ def analyze_project_path(
     project_path: str,
     include_main: bool = False,
     extra_args: str | list[str] | None = None,
+    backend: str = "auto",
 ) -> dict[str, object]:
     root, source_paths = source_paths_from_project_path(project_path, ASSISTANT)
     reports = ASSISTANT.analyze_files(
-        source_paths, include_main, extra_args=extra_args, root=root
+        source_paths, include_main, backend=backend, extra_args=extra_args, root=root
     )
     text_report = ASSISTANT.format_text_report(reports)
     llm_prompt = ASSISTANT.format_llm_prompt(reports)
@@ -800,24 +824,31 @@ class ContractAssistantGuiHandler(BaseHTTPRequestHandler):
                 )
             elif self.path == "/api/llm-suggest":
                 include_main = bool(payload.get("include_main", False))
+                backend = analysis_backend_from_payload(payload)
                 if not has_project_path(payload):
                     raise ValueError("Project path is required for LLM suggestions")
                 response = suggest_contracts(
                     str(payload["project_path"]),
                     include_main,
                     payload.get("extra_args"),
+                    backend,
                 )
             elif self.path == "/api/analyze":
                 include_main = bool(payload.get("include_main", False))
+                backend = analysis_backend_from_payload(payload)
                 if has_project_path(payload):
                     response = analyze_project_path(
                         str(payload["project_path"]),
                         include_main,
                         payload.get("extra_args"),
+                        backend,
                     )
                 else:
                     response = analyze_project(
-                        payload_files(payload), include_main, payload.get("extra_args")
+                        payload_files(payload),
+                        include_main,
+                        payload.get("extra_args"),
+                        backend,
                     )
             else:
                 mode = str(payload.get("mode", "eva"))

--- a/Dockerfiles/bin/autodeduct-contract-assistant-gui
+++ b/Dockerfiles/bin/autodeduct-contract-assistant-gui
@@ -485,7 +485,8 @@ HTML_PAGE = r"""<!doctype html>
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             project_path: requestProjectPath(),
-            include_main: includeMain.checked
+            include_main: includeMain.checked,
+            extra_args: framacArgsInput.value
           })
         });
         const data = await response.json();
@@ -515,7 +516,8 @@ HTML_PAGE = r"""<!doctype html>
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             project_path: requestProjectPath(),
-            include_main: includeMain.checked
+            include_main: includeMain.checked,
+            extra_args: framacArgsInput.value
           })
         });
         const data = await response.json();
@@ -605,6 +607,22 @@ def pipeline_for_reports(reports: list[object]) -> list[dict[str, str]]:
     missing_helpers = [
         function for report in reports for function in report.missing_helper_contracts
     ]
+    backends = sorted(
+        {str(getattr(report, "analysis_backend", "source-scan")) for report in reports}
+    )
+    warnings = [
+        str(getattr(report, "analysis_warning"))
+        for report in reports
+        if getattr(report, "analysis_warning", None)
+    ]
+    helper_detail = (
+        f"{len(missing_helpers)} reachable helper function(s) miss contracts."
+        if missing_helpers
+        else "No reachable helper functions are missing contracts."
+    )
+    helper_detail += f" Backend: {', '.join(backends)}."
+    if warnings:
+        helper_detail += f" Warning: {warnings[0]}"
     return [
         {
             "status": "ok" if functions else "warn",
@@ -626,11 +644,7 @@ def pipeline_for_reports(reports: list[object]) -> list[dict[str, str]]:
         {
             "status": "warn" if missing_helpers else "ok",
             "name": "Check helper contracts",
-            "detail": (
-                f"{len(missing_helpers)} reachable helper function(s) miss contracts."
-                if missing_helpers
-                else "No reachable helper functions are missing contracts."
-            ),
+            "detail": helper_detail,
         },
         {
             "status": "skip",
@@ -679,13 +693,23 @@ def list_project_path(project_path: str | None) -> dict[str, object]:
     return list_container_path(project_path, ASSISTANT.SOURCE_SUFFIXES)
 
 
-def suggest_contracts(project_path: str, include_main: bool = False) -> dict[str, object]:
+def suggest_contracts(
+    project_path: str,
+    include_main: bool = False,
+    extra_args: str | list[str] | None = None,
+) -> dict[str, object]:
     root, source_paths = source_paths_from_project_path(project_path, ASSISTANT)
-    reports = ASSISTANT.analyze_files(source_paths, include_main)
+    reports = ASSISTANT.analyze_files(
+        source_paths, include_main, extra_args=extra_args, root=root
+    )
     return suggest_contracts_from_reports(reports, root, pipeline_for_reports)
 
 
-def analyze_project(files: list[dict[str, str]], include_main: bool = False) -> dict[str, object]:
+def analyze_project(
+    files: list[dict[str, str]],
+    include_main: bool = False,
+    extra_args: str | list[str] | None = None,
+) -> dict[str, object]:
     with tempfile.TemporaryDirectory(prefix="autodeduct-contract-assistant-") as tmpdir:
         root = Path(tmpdir)
         written = write_project_files(files, root)
@@ -694,7 +718,9 @@ def analyze_project(files: list[dict[str, str]], include_main: bool = False) -> 
         ]
         if not source_paths:
             raise ValueError("No .c or .h source files were provided")
-        reports = ASSISTANT.analyze_files(source_paths, include_main)
+        reports = ASSISTANT.analyze_files(
+            source_paths, include_main, extra_args=extra_args, root=root
+        )
         text_report = ASSISTANT.format_text_report(reports)
         llm_prompt = ASSISTANT.format_llm_prompt(reports)
         return {
@@ -706,9 +732,15 @@ def analyze_project(files: list[dict[str, str]], include_main: bool = False) -> 
         }
 
 
-def analyze_project_path(project_path: str, include_main: bool = False) -> dict[str, object]:
+def analyze_project_path(
+    project_path: str,
+    include_main: bool = False,
+    extra_args: str | list[str] | None = None,
+) -> dict[str, object]:
     root, source_paths = source_paths_from_project_path(project_path, ASSISTANT)
-    reports = ASSISTANT.analyze_files(source_paths, include_main)
+    reports = ASSISTANT.analyze_files(
+        source_paths, include_main, extra_args=extra_args, root=root
+    )
     text_report = ASSISTANT.format_text_report(reports)
     llm_prompt = ASSISTANT.format_llm_prompt(reports)
     return {
@@ -770,13 +802,23 @@ class ContractAssistantGuiHandler(BaseHTTPRequestHandler):
                 include_main = bool(payload.get("include_main", False))
                 if not has_project_path(payload):
                     raise ValueError("Project path is required for LLM suggestions")
-                response = suggest_contracts(str(payload["project_path"]), include_main)
+                response = suggest_contracts(
+                    str(payload["project_path"]),
+                    include_main,
+                    payload.get("extra_args"),
+                )
             elif self.path == "/api/analyze":
                 include_main = bool(payload.get("include_main", False))
                 if has_project_path(payload):
-                    response = analyze_project_path(str(payload["project_path"]), include_main)
+                    response = analyze_project_path(
+                        str(payload["project_path"]),
+                        include_main,
+                        payload.get("extra_args"),
+                    )
                 else:
-                    response = analyze_project(payload_files(payload), include_main)
+                    response = analyze_project(
+                        payload_files(payload), include_main, payload.get("extra_args")
+                    )
             else:
                 mode = str(payload.get("mode", "eva"))
                 if has_project_path(payload):

--- a/Dockerfiles/bin/autodeduct_contract_assistant_draft.py
+++ b/Dockerfiles/bin/autodeduct_contract_assistant_draft.py
@@ -15,10 +15,39 @@ from autodeduct_contract_assistant_project import (
 )
 
 
-def normalize_contract(contract: str) -> str:
+def strip_markdown_code_fence(contract: str) -> str:
     stripped = contract.strip()
-    if stripped.startswith("/*@") and stripped.endswith("*/"):
+    if not stripped.startswith("```"):
+        return stripped
+
+    lines = stripped.splitlines()
+    if len(lines) >= 2 and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return stripped
+
+
+def ensure_no_nested_block_comment(contract: str) -> None:
+    if "/*" in contract or "*/" in contract:
+        raise ValueError(
+            "Draft contract contains nested C block-comment markers. "
+            "Edit the draft so the contract is one ACSL block comment only."
+        )
+
+
+def normalize_contract(contract: str) -> str:
+    stripped = strip_markdown_code_fence(contract)
+    if stripped.startswith("/*"):
+        if not stripped.startswith("/*@"):
+            raise ValueError(
+                "Draft contract must be an ACSL block comment starting with /*@, "
+                "not a regular C comment."
+            )
+        if not stripped.endswith("*/"):
+            raise ValueError("Draft ACSL block comment is missing its closing */")
+        ensure_no_nested_block_comment(stripped[3:-2])
         return stripped + "\n"
+
+    ensure_no_nested_block_comment(stripped)
     lines = ["/*@"]
     for line in stripped.splitlines():
         lines.append("  " + line.strip())

--- a/Dockerfiles/bin/autodeduct_contract_assistant_openai.py
+++ b/Dockerfiles/bin/autodeduct_contract_assistant_openai.py
@@ -63,7 +63,9 @@ def llm_contract_prompt(reports: list[Any], root: Path) -> str:
     return (
         "Generate draft ACSL contracts for the missing helper functions below.\n"
         "Return JSON only. Each contract must be a complete ACSL block comment "
-        "that can be inserted immediately before the named function.\n"
+        "that starts with /*@ and ends with */ and can be inserted immediately "
+        "before the named function. Do not use /** comments, Markdown fences, "
+        "or nested /* ... */ comments inside the contract string.\n"
         "Do not modify function bodies, include directives, global variables, or "
         "files not listed here. Prefer conservative requires/assigns/ensures "
         "clauses. If a precise postcondition is not justified by the code, say so "

--- a/README.md
+++ b/README.md
@@ -120,6 +120,68 @@ When a directory is provided, the assistant builds a lightweight project-level
 call graph across the scanned files, so a contracted function in `main.c` can
 identify a missing helper contract in another `.c` file.
 
+### Contract assistant architecture
+
+The contract assistant is a thin workflow layer around Frama-C/ISP, the local
+source files, and optional LLM draft generation:
+
+```text
+Host project folder
+  |
+  | mounted by scripts/autodeduct-contract-assistant-gui-docker
+  v
+AutoDeduct Docker container (/project)
+  |
+  +-- CLI: autodeduct-contract-assistant
+  |
+  +-- GUI: autodeduct-contract-assistant-gui
+        |
+        +-- Browse mounted Docker path
+        +-- Run missing-helper analysis
+        +-- Run Eva / WP
+        +-- Generate editable LLM contract draft
+```
+
+The missing-helper analysis has two backends:
+
+```text
+C source files + headers + Frama-C options
+  |
+  v
+backend=auto
+  |
+  +-- preferred: Frama-C + ISP
+  |       |
+  |       +-- ISP writes missing-helper JSON
+  |       +-- AutoDeduct maps JSON entries back to source snippets
+  |
+  +-- fallback: built-in source scan
+          |
+          +-- Lightweight function and call graph scan
+          +-- Used when Frama-C/ISP cannot parse the project yet
+```
+
+The LLM step is optional and draft-only:
+
+```text
+Missing helper list + source snippets
+  |
+  v
+OpenAI API, if OPENAI_API_KEY is set
+  |
+  v
+Editable ACSL draft JSON in the GUI
+  |
+  v
+Temporary copy of the project
+  |
+  v
+Frama-C/WP or Eva validation
+```
+
+The original mounted source files are not modified by the GUI draft flow.
+Draft contracts are inserted only into a temporary copy used for validation.
+
 The backend can be selected explicitly:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ autodeduct-contract-assistant \
 
 The ISP backend requires an ISP version that provides
 `-isp-missing-helper-contracts-json`. If you are testing before that ISP change
-is released, build the image with the matching ISP branch:
+is released, build the image with the matching remote ISP branch:
 
 ```shell
 cd Dockerfiles
@@ -212,18 +212,83 @@ docker build \
   -f AutoDeductDockerfile .
 ```
 
+The Dockerfile does not have to use ISP `main`; it uses the `ISP_VER` build
+argument, which may be a tag, branch, or commit that Git can clone from the ISP
+repository. The default is the released version set in `AutoDeductDockerfile`.
+
+For quick local ISP experiments without pushing a branch first, mount your local
+ISP checkout into the container and install it inside that running container:
+
+```shell
+docker run -it --rm \
+  -v "/path/to/interface-specification-propagator":/isp-src \
+  -v "/path/to/case-study":/project \
+  -w /project \
+  auto-deduct:latest \
+  /usr/bin/bash -l
+
+cd /isp-src
+dune build @install
+dune install
+
+cd /project
+autodeduct-contract-assistant --backend isp .
+```
+
+That local install is only for the running container. For a reusable image,
+push the ISP branch and build AutoDeduct with `--build-arg ISP_VER=<branch>`.
+
 Case-study sources are intentionally kept outside this toolchain repository.
 Pass a local case-study path directly to the assistant, or mount that path into
 Docker when using the container.
 
-To run the CLI helper against files in your current directory from Docker:
+### Step-by-step Docker run
+
+Build the image:
+
+```shell
+cd /path/to/auto-deduct-toolchain/Dockerfiles
+docker build -t auto-deduct:latest -f AutoDeductDockerfile .
+```
+
+If you need the ISP missing-helper report before it is released, build with the
+ISP branch:
+
+```shell
+docker build \
+  --build-arg ISP_VER=feature/missing-helper-contract-report \
+  -t auto-deduct:latest \
+  -f AutoDeductDockerfile .
+```
+
+Run the CLI against a mounted project:
 
 ```shell
 docker run -it --rm \
-  -v "$PWD":/work \
-  -w /work \
-  auto-deduct \
-  /usr/bin/bash -l -c 'autodeduct-contract-assistant path/to/case-study'
+  -v "/path/to/case-study":/project \
+  -w /project \
+  auto-deduct:latest \
+  /usr/bin/bash -l -c 'autodeduct-contract-assistant --backend auto .'
+```
+
+To force the precise ISP backend and fail if Frama-C/ISP cannot run:
+
+```shell
+docker run -it --rm \
+  -v "/path/to/case-study":/project \
+  -w /project \
+  auto-deduct:latest \
+  /usr/bin/bash -l -c 'autodeduct-contract-assistant --backend isp .'
+```
+
+To use only the fallback source scanner:
+
+```shell
+docker run -it --rm \
+  -v "/path/to/case-study":/project \
+  -w /project \
+  auto-deduct:latest \
+  /usr/bin/bash -l -c 'autodeduct-contract-assistant --backend source .'
 ```
 
 For machine-readable output, use:
@@ -267,6 +332,12 @@ If you mounted a larger folder but only want to run one sub-example, use
 `Browse Docker Path` in the GUI. It lists the Docker/container view of the
 mounted folder, so you can click from `/project` into the exact subdirectory or
 source file you want to analyze.
+
+The GUI has a `Missing-helper backend` selector:
+
+* `Auto`: try ISP/Frama-C first and fall back to the source scan.
+* `ISP/Frama-C only`: fail if the ISP JSON report cannot be generated.
+* `Source scan only`: use the lightweight source scanner without Frama-C.
 
 If port `8765` is already busy, choose another host port:
 

--- a/README.md
+++ b/README.md
@@ -111,13 +111,44 @@ cd Dockerfiles
 docker build -t auto-deduct:latest -f AutoDeductDockerfile .
 ```
 
-The assistant scans C function definitions, detects ACSL contracts immediately
-above functions, and reports helper functions that are reachable from contracted
-functions but do not have contracts themselves. This is a deterministic
-pre-check; it does not prove or generate contracts.
+By default, the assistant tries to use the ISP Frama-C plugin to generate the
+missing-helper report, then falls back to its built-in source scan if Frama-C,
+ISP, or the needed preprocessor setup is not available. The built-in scan is
+also used to extract source snippets for the report and LLM prompt. This is a
+deterministic pre-check; it does not prove or generate contracts.
 When a directory is provided, the assistant builds a lightweight project-level
 call graph across the scanned files, so a contracted function in `main.c` can
 identify a missing helper contract in another `.c` file.
+
+The backend can be selected explicitly:
+
+```shell
+autodeduct-contract-assistant --backend auto path/to/case-study
+autodeduct-contract-assistant --backend isp path/to/case-study
+autodeduct-contract-assistant --backend source path/to/case-study
+```
+
+Use `--backend isp` when you want the command to fail instead of falling back to
+the source scan. If the project needs include paths or macros before Frama-C can
+parse it, pass the same options that you would pass to Frama-C:
+
+```shell
+autodeduct-contract-assistant \
+  --frama-c-extra-args '-cpp-extra-args="-D__GNUC__=12 -Ioriginal"' \
+  path/to/case-study
+```
+
+The ISP backend requires an ISP version that provides
+`-isp-missing-helper-contracts-json`. If you are testing before that ISP change
+is released, build the image with the matching ISP branch:
+
+```shell
+cd Dockerfiles
+docker build \
+  --build-arg ISP_VER=feature/missing-helper-contract-report \
+  -t auto-deduct:latest \
+  -f AutoDeductDockerfile .
+```
 
 Case-study sources are intentionally kept outside this toolchain repository.
 Pass a local case-study path directly to the assistant, or mount that path into
@@ -198,8 +229,10 @@ The launcher mounts the selected local project folder as:
 ```
 
 The GUI also has `Run Eva` and `Run WP` buttons. These run Frama-C on the
-selected `.c` files and show the command output. Header files must be available
-through the mounted project path or through include paths passed to Frama-C.
+selected `.c` files and show the command output. The same `Extra Frama-C
+options` field is used by the ISP missing-helper backend, the Eva run, and the
+WP run. Header files must be available through the mounted project path or
+through include paths passed to Frama-C.
 
 The GUI can optionally call the OpenAI API to draft ACSL contracts for missing
 helper functions. The API key is read only from the environment and is not

--- a/README.md
+++ b/README.md
@@ -173,14 +173,16 @@ OpenAI API, if OPENAI_API_KEY is set
 Editable ACSL draft JSON in the GUI
   |
   v
-Temporary copy of the project
+Temporary copy of the project, only for Run WP with Draft
   |
   v
-Frama-C/WP or Eva validation
+Frama-C/WP draft validation
 ```
 
-The original mounted source files are not modified by the GUI draft flow.
-Draft contracts are inserted only into a temporary copy used for validation.
+The normal `Run Eva` and `Run WP` buttons run Frama-C on the mounted source
+files. The `Run WP with Draft` button is different: it inserts the edited draft
+contracts into a temporary copy and validates that copy, so the original mounted
+source files are not modified by the LLM draft flow.
 
 The backend can be selected explicitly:
 
@@ -200,43 +202,8 @@ autodeduct-contract-assistant \
   path/to/case-study
 ```
 
-The ISP backend requires an ISP version that provides
-`-isp-missing-helper-contracts-json`. If you are testing before that ISP change
-is released, build the image with the matching remote ISP branch:
-
-```shell
-cd Dockerfiles
-docker build \
-  --build-arg ISP_VER=feature/missing-helper-contract-report \
-  -t auto-deduct:latest \
-  -f AutoDeductDockerfile .
-```
-
-The Dockerfile does not have to use ISP `main`; it uses the `ISP_VER` build
-argument, which may be a tag, branch, or commit that Git can clone from the ISP
-repository. The default is the released version set in `AutoDeductDockerfile`.
-
-For quick local ISP experiments without pushing a branch first, mount your local
-ISP checkout into the container and install it inside that running container:
-
-```shell
-docker run -it --rm \
-  -v "/path/to/interface-specification-propagator":/isp-src \
-  -v "/path/to/case-study":/project \
-  -w /project \
-  auto-deduct:latest \
-  /usr/bin/bash -l
-
-cd /isp-src
-dune build @install
-dune install
-
-cd /project
-autodeduct-contract-assistant --backend isp .
-```
-
-That local install is only for the running container. For a reusable image,
-push the ISP branch and build AutoDeduct with `--build-arg ISP_VER=<branch>`.
+The ISP backend requires an AutoDeduct image that contains an ISP version
+providing `-isp-missing-helper-contracts-json`.
 
 Case-study sources are intentionally kept outside this toolchain repository.
 Pass a local case-study path directly to the assistant, or mount that path into
@@ -249,16 +216,6 @@ Build the image:
 ```shell
 cd /path/to/auto-deduct-toolchain/Dockerfiles
 docker build -t auto-deduct:latest -f AutoDeductDockerfile .
-```
-
-If you need the ISP missing-helper report before it is released, build with the
-ISP branch:
-
-```shell
-docker build \
-  --build-arg ISP_VER=feature/missing-helper-contract-report \
-  -t auto-deduct:latest \
-  -f AutoDeductDockerfile .
 ```
 
 Run the CLI against a mounted project:

--- a/tests/test_contract_assistant.py
+++ b/tests/test_contract_assistant.py
@@ -133,6 +133,106 @@ int main(void) {
         self.assertEqual(reports["b.c"]["missing_helper_contracts"], [])
         self.assertEqual(reports["b.c"]["called_by"]["helper"], [])
 
+    def test_isp_report_mapping_is_authoritative_for_duplicate_names(self):
+        assistant = load_script("autodeduct_contract_assistant_backend", ASSISTANT)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "a.c").write_text(
+                """static void helper(int *p) {
+  *p = *p + 1;
+}
+
+/*@
+  ensures \\result >= 0;
+*/
+int main(void) {
+  int x = 0;
+  helper(&x);
+  return x;
+}
+""",
+                encoding="utf-8",
+            )
+            (root / "b.c").write_text(
+                """static void helper(int *p) {
+  *p = *p + 2;
+}
+""",
+                encoding="utf-8",
+            )
+
+            reports = assistant.analyze_files([root], False, backend="source")
+            mapped = assistant.apply_isp_missing_helper_report(
+                reports,
+                {
+                    "missing_helper_contracts": [
+                        {
+                            "function": "helper",
+                            "file": "b.c",
+                            "line": 1,
+                            "called_by": [
+                                {"function": "contracted_entry", "file": "b.c", "line": 7}
+                            ],
+                        }
+                    ]
+                },
+                root,
+            )
+
+        reports_by_name = {report.path.name: report for report in mapped}
+        self.assertEqual(reports_by_name["a.c"].missing_helper_contracts, [])
+        self.assertEqual(
+            [function.name for function in reports_by_name["b.c"].missing_helper_contracts],
+            ["helper"],
+        )
+        self.assertEqual(
+            reports_by_name["b.c"].called_by["helper"], ["contracted_entry"]
+        )
+        self.assertEqual(reports_by_name["b.c"].analysis_backend, "isp-frama-c")
+
+    def test_auto_backend_falls_back_to_source_scan_when_isp_is_unavailable(self):
+        assistant = load_script("autodeduct_contract_assistant_fallback", ASSISTANT)
+        original_runner = assistant.run_isp_missing_helper_report
+
+        def failing_runner(*_args, **_kwargs):
+            raise RuntimeError("test ISP failure")
+
+        assistant.run_isp_missing_helper_report = failing_runner
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                (root / "helper.c").write_text(
+                    "void helper(int *p) { *p = *p + 1; }\n",
+                    encoding="utf-8",
+                )
+                (root / "main.c").write_text(
+                    """int value;
+/*@
+  ensures value >= 0;
+*/
+int main(void) {
+  helper(&value);
+  return 0;
+}
+""",
+                    encoding="utf-8",
+                )
+
+                reports = assistant.analyze_files([root], False, backend="auto")
+        finally:
+            assistant.run_isp_missing_helper_report = original_runner
+
+        missing_helpers = [
+            function.name
+            for report in reports
+            for function in report.missing_helper_contracts
+        ]
+        self.assertEqual(missing_helpers, ["helper"])
+        self.assertTrue(all(report.analysis_backend == "source-scan" for report in reports))
+        self.assertTrue(
+            all("test ISP failure" in report.analysis_warning for report in reports)
+        )
+
     def test_directory_fixture_reports_domain_named_missing_helper_contract(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_contract_assistant.py
+++ b/tests/test_contract_assistant.py
@@ -353,6 +353,35 @@ int main(void) {
         self.assertEqual(missing_helpers, ["helper"])
         self.assertIn("helper.c", response["summary"])
 
+    def test_gui_analysis_accepts_backend_selection(self):
+        gui = load_script("autodeduct_contract_assistant_gui_backend", GUI)
+
+        response = gui.analyze_project(
+            [
+                {
+                    "filename": "helper.c",
+                    "code": "void helper(int *p) { *p = *p + 1; }\n",
+                },
+                {
+                    "filename": "main.c",
+                    "code": """int value;
+/*@
+  ensures value >= 0;
+*/
+int main(void) {
+  helper(&value);
+  return 0;
+}
+""",
+                },
+            ],
+            include_main=False,
+            backend="source",
+        )
+
+        self.assertEqual(response["report"][0]["analysis_backend"], "source-scan")
+        self.assertIn("Backend: source-scan.", response["pipeline"][2]["detail"])
+
     def test_gui_lists_container_project_path(self):
         gui = load_script("autodeduct_contract_assistant_gui_list_path", GUI)
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_contract_assistant.py
+++ b/tests/test_contract_assistant.py
@@ -462,6 +462,44 @@ int main(void) {
                 (copy / "helper.c").read_text(encoding="utf-8").startswith("/*@")
             )
 
+    def test_contract_draft_rejects_regular_c_block_comment(self):
+        gui = load_script("autodeduct_contract_assistant_gui_bad_comment", GUI)
+
+        with self.assertRaisesRegex(ValueError, "starting with /\\*@"):
+            gui.apply_contract_draft_to_copy(
+                Path("/tmp/original"),
+                Path("/tmp/copy"),
+                [],
+                {
+                    "suggestions": [
+                        {
+                            "file": "helper.c",
+                            "function": "helper",
+                            "contract": "/**\n * assigns *p;\n */",
+                        }
+                    ]
+                },
+            )
+
+    def test_contract_draft_rejects_nested_block_comment_markers(self):
+        gui = load_script("autodeduct_contract_assistant_gui_nested_comment", GUI)
+
+        with self.assertRaisesRegex(ValueError, "nested C block-comment"):
+            gui.apply_contract_draft_to_copy(
+                Path("/tmp/original"),
+                Path("/tmp/copy"),
+                [],
+                {
+                    "suggestions": [
+                        {
+                            "file": "helper.c",
+                            "function": "helper",
+                            "contract": "/*@\n  /* bad nested comment */\n  assigns *p;\n*/",
+                        }
+                    ]
+                },
+            )
+
     def test_gui_frama_c_command_accepts_extra_args(self):
         gui = load_script("autodeduct_contract_assistant_gui_args", GUI)
 


### PR DESCRIPTION
## Summary

Updates the AutoDeduct contract assistant so missing helper contracts can be detected through the ISP/Frama-C report instead of relying only on the built-in source scanner.

The assistant now has three backend modes:

- `auto`: try ISP/Frama-C first, fall back to source scan
- `isp`: require the ISP/Frama-C JSON report
- `source`: use only the built-in source scan

## What changed

- Added `--backend auto|isp|source` to `autodeduct-contract-assistant`.
- Added `--frama-c-extra-args` so the ISP backend can receive include paths/macros.
- Added GUI backend selector for missing-helper analysis.
- GUI now passes Extra Frama-C options to the missing-helper backend.
- AutoDeduct maps ISP JSON report entries back to local source snippets for LLM prompts.
- Added fallback behavior when Frama-C/ISP cannot parse the project.
- Added validation for LLM draft ACSL comments before `Run WP with Draft`.
- Updated README with architecture, Docker run flow, backend behavior, and GUI usage.
- Added tests for ISP JSON mapping, fallback behavior, GUI backend selection, and draft comment validation.

## Why

AutoDeduct originally detected missing helper contracts using a lightweight Python/source scan. That is useful as a fallback, but Frama-C/ISP has the parsed AST and resolved functions, so it is a better source of truth.

This also avoids conflating helper functions with the same name across files when ISP provides the report.

## Dependency

The `isp` backend requires an ISP version that provides:

```text
-isp-missing-helper-contracts-json